### PR TITLE
Add `const` to `fn new` on color models where possible

### DIFF
--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -44,10 +44,10 @@ where
     InnerColor: Color,
 {
     /// Construct an `Alpha` object from a color and an alpha value
-    pub fn new(color: InnerColor, alpha: T) -> Self {
+    pub const fn new(color: InnerColor, alpha: T) -> Self {
         Alpha {
             color,
-            alpha: PosNormalBoundedChannel::new(alpha),
+            alpha: PosNormalBoundedChannel::new_const(alpha),
         }
     }
     /// Break apart an `Alpha` into the inner color and alpha channel value

--- a/src/channel/angular_channel.rs
+++ b/src/channel/angular_channel.rs
@@ -24,7 +24,7 @@ where
     T: Angle,
 {
     /// Construct a new `AngularChannel`
-    pub fn new(val: T) -> Self {
+    pub const fn new(val: T) -> Self {
         AngularChannel(val)
     }
 }

--- a/src/channel/bounded_channel.rs
+++ b/src/channel/bounded_channel.rs
@@ -21,6 +21,14 @@ pub struct NormalChannelTag;
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PosNormalBoundedChannel<T>(pub T);
+
+impl<T> PosNormalBoundedChannel<T> {
+    /// Construct a new `PosNormalBoundedChannel`
+    pub const fn new_const(val: T) -> Self {
+        PosNormalBoundedChannel(val)
+    }
+}
+
 /// A channel bounded between a minimum and a maximum value
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/channel/free_channel.rs
+++ b/src/channel/free_channel.rs
@@ -16,10 +16,25 @@ pub struct PosFreeChannelTag;
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
 pub struct PosFreeChannel<T>(pub T);
+
+impl<T> PosFreeChannel<T> {
+    /// Construct a new `PosFreeChannel`
+    pub const fn new_const(val: T) -> Self {
+        PosFreeChannel(val)
+    }
+}
+
 /// A free channel with no constraints
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
 pub struct FreeChannel<T>(pub T);
+
+impl<T> FreeChannel<T> {
+    /// Construct a new `PosFreeChannel`
+    pub const fn new_const(val: T) -> Self {
+        FreeChannel(val)
+    }
+}
 
 impl<T> ColorChannel for PosFreeChannel<T>
 where

--- a/src/ehsi.rs
+++ b/src/ehsi.rs
@@ -1,8 +1,8 @@
 //! The eHSI device-dependent polar color model
 
 use crate::channel::{
-    AngularChannel, AngularChannelScalar, ChannelCast, ChannelFormatCast, ColorChannel,
-    PosNormalBoundedChannel, PosNormalChannelScalar,
+    AngularChannel, AngularChannelScalar, ChannelCast, ChannelFormatCast, PosNormalBoundedChannel,
+    PosNormalChannelScalar,
 };
 use crate::color;
 use crate::color::{Bounded, Color, FromTuple, Invert, Lerp, PolarColor};
@@ -48,11 +48,11 @@ where
     A: AngularChannelScalar + Angle<Scalar = T>,
 {
     /// Construct an eHsi instance from hue, saturation and intensity.
-    pub fn new(hue: A, saturation: T, intensity: T) -> Self {
+    pub const fn new(hue: A, saturation: T, intensity: T) -> Self {
         eHsi {
             hue: AngularChannel::new(hue),
-            saturation: PosNormalBoundedChannel::new(saturation),
-            intensity: PosNormalBoundedChannel::new(intensity),
+            saturation: PosNormalBoundedChannel::new_const(saturation),
+            intensity: PosNormalBoundedChannel::new_const(intensity),
         }
     }
 

--- a/src/hsi.rs
+++ b/src/hsi.rs
@@ -1,8 +1,8 @@
 //! The HSI device-dependent polar color space
 
 use crate::channel::{
-    AngularChannel, AngularChannelScalar, ChannelCast, ChannelFormatCast, ColorChannel,
-    PosNormalBoundedChannel, PosNormalChannelScalar,
+    AngularChannel, AngularChannelScalar, ChannelCast, ChannelFormatCast, PosNormalBoundedChannel,
+    PosNormalChannelScalar,
 };
 use crate::color;
 use crate::color::{Bounded, Color, FromTuple, Invert, Lerp, PolarColor};
@@ -60,11 +60,11 @@ where
     A: AngularChannelScalar + Angle<Scalar = T>,
 {
     /// Construct an `Hsi` instance from hue, saturation and intensity
-    pub fn new(hue: A, saturation: T, intensity: T) -> Self {
+    pub const fn new(hue: A, saturation: T, intensity: T) -> Self {
         Hsi {
             hue: AngularChannel::new(hue),
-            saturation: PosNormalBoundedChannel::new(saturation),
-            intensity: PosNormalBoundedChannel::new(intensity),
+            saturation: PosNormalBoundedChannel::new_const(saturation),
+            intensity: PosNormalBoundedChannel::new_const(intensity),
         }
     }
 

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -1,8 +1,8 @@
 //! The HSL device-dependent polar color model
 
 use crate::channel::{
-    AngularChannel, AngularChannelScalar, ChannelCast, ChannelFormatCast, ColorChannel,
-    PosNormalBoundedChannel, PosNormalChannelScalar,
+    AngularChannel, AngularChannelScalar, ChannelCast, ChannelFormatCast, PosNormalBoundedChannel,
+    PosNormalChannelScalar,
 };
 use crate::color;
 use crate::color::{Color, FromTuple};
@@ -52,11 +52,11 @@ where
     A: AngularChannelScalar,
 {
     /// Construct an `Hsl` instance from hue, saturation and lightness
-    pub fn new(hue: A, saturation: T, lightness: T) -> Self {
+    pub const fn new(hue: A, saturation: T, lightness: T) -> Self {
         Hsl {
             hue: AngularChannel::new(hue),
-            saturation: PosNormalBoundedChannel::new(saturation),
-            lightness: PosNormalBoundedChannel::new(lightness),
+            saturation: PosNormalBoundedChannel::new_const(saturation),
+            lightness: PosNormalBoundedChannel::new_const(lightness),
         }
     }
 

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -2,7 +2,7 @@
 
 use crate::channel::cast::ChannelFormatCast;
 use crate::channel::{
-    AngularChannel, AngularChannelScalar, ChannelCast, ColorChannel, PosNormalBoundedChannel,
+    AngularChannel, AngularChannelScalar, ChannelCast, PosNormalBoundedChannel,
     PosNormalChannelScalar,
 };
 use crate::color;
@@ -51,11 +51,11 @@ where
     A: AngularChannelScalar,
 {
     /// Construct an Hsv instance from hue, saturation and value
-    pub fn new(hue: A, saturation: T, value: T) -> Self {
+    pub const fn new(hue: A, saturation: T, value: T) -> Self {
         Hsv {
             hue: AngularChannel::new(hue),
-            saturation: PosNormalBoundedChannel::new(saturation),
-            value: PosNormalBoundedChannel::new(value),
+            saturation: PosNormalBoundedChannel::new_const(saturation),
+            value: PosNormalBoundedChannel::new_const(value),
         }
     }
 

--- a/src/hwb.rs
+++ b/src/hwb.rs
@@ -49,11 +49,11 @@ where
     A: AngularChannelScalar,
 {
     /// Construct a `Hwb` instance from hue, whiteness and blackness
-    pub fn new(hue: A, whiteness: T, blackness: T) -> Self {
+    pub const fn new(hue: A, whiteness: T, blackness: T) -> Self {
         Hwb {
             hue: AngularChannel::new(hue),
-            whiteness: PosNormalBoundedChannel::new(whiteness),
-            blackness: PosNormalBoundedChannel::new(blackness),
+            whiteness: PosNormalBoundedChannel::new_const(whiteness),
+            blackness: PosNormalBoundedChannel::new_const(blackness),
         }
     }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -45,12 +45,12 @@ where
     ///
     /// Unlike `new_with_whitepoint`, `new` constructs a default instance of a [`UnitWhitePoint`](white_point/trait.UnitWhitePoint.html).
     /// It is only valid when `W` is a `UnitWhitePoint`.
-    pub fn new(L: T, a: T, b: T) -> Self {
+    pub const fn new(L: T, a: T, b: T) -> Self {
         Lab {
-            L: PosFreeChannel::new(L),
-            a: FreeChannel::new(a),
-            b: FreeChannel::new(b),
-            white_point: W::default(),
+            L: PosFreeChannel::new_const(L),
+            a: FreeChannel::new_const(a),
+            b: FreeChannel::new_const(b),
+            white_point: W::DEFAULT,
         }
     }
 }

--- a/src/lchab.rs
+++ b/src/lchab.rs
@@ -50,12 +50,12 @@ where
     ///
     /// Unlike `new_with_whitepoint`, `new` constructs a default instance of a [`UnitWhitePoint`](white_point/trait.UnitWhitePoint.html).
     /// It is only valid when `W` is a `UnitWhitePoint`.
-    pub fn new(L: T, chroma: T, hue: A) -> Self {
+    pub const fn new(L: T, chroma: T, hue: A) -> Self {
         Lchab {
-            L: PosFreeChannel::new(L),
-            chroma: PosFreeChannel::new(chroma),
+            L: PosFreeChannel::new_const(L),
+            chroma: PosFreeChannel::new_const(chroma),
             hue: AngularChannel::new(hue),
-            white_point: W::default(),
+            white_point: W::DEFAULT,
         }
     }
 }

--- a/src/lchuv.rs
+++ b/src/lchuv.rs
@@ -50,12 +50,12 @@ where
     ///
     /// Unlike `new_with_whitepoint`, `new` constructs a default instance of a [`UnitWhitePoint`](white_point/trait.UnitWhitePoint.html).
     /// It is only valid when `W` is a `UnitWhitePoint`.
-    pub fn new(L: T, chroma: T, hue: A) -> Self {
+    pub const fn new(L: T, chroma: T, hue: A) -> Self {
         Lchuv {
-            L: PosFreeChannel::new(L),
-            chroma: PosFreeChannel::new(chroma),
+            L: PosFreeChannel::new_const(L),
+            chroma: PosFreeChannel::new_const(chroma),
             hue: AngularChannel::new(hue),
-            white_point: W::default(),
+            white_point: W::DEFAULT,
         }
     }
 }

--- a/src/lms.rs
+++ b/src/lms.rs
@@ -72,11 +72,11 @@ where
     Model: LmsModel<T>,
 {
     /// Construct an `LMS` instance from `l`, `m` and `s`
-    pub fn new(l: T, m: T, s: T) -> Self {
+    pub const fn new(l: T, m: T, s: T) -> Self {
         Lms {
-            l: FreeChannel::new(l),
-            m: FreeChannel::new(m),
-            s: FreeChannel::new(s),
+            l: FreeChannel::new_const(l),
+            m: FreeChannel::new_const(m),
+            s: FreeChannel::new_const(s),
             model: PhantomData,
         }
     }

--- a/src/luv.rs
+++ b/src/luv.rs
@@ -41,12 +41,12 @@ where
     ///
     /// Unlike `new_with_whitepoint`, `new` constructs a default instance of a [`UnitWhitePoint`](white_point/trait.UnitWhitePoint.html).
     /// It is only valid when `W` is a `UnitWhitePoint`.
-    pub fn new(L: T, u: T, v: T) -> Self {
+    pub const fn new(L: T, u: T, v: T) -> Self {
         Luv {
-            L: PosFreeChannel::new(L),
-            u: FreeChannel::new(u),
-            v: FreeChannel::new(v),
-            white_point: W::default(),
+            L: PosFreeChannel::new_const(L),
+            u: FreeChannel::new_const(u),
+            v: FreeChannel::new_const(v),
+            white_point: W::DEFAULT,
         }
     }
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -63,11 +63,11 @@ where
     T: PosNormalChannelScalar,
 {
     /// Construct a new `Rgb` instance with the given channel values
-    pub fn new(red: T, green: T, blue: T) -> Self {
+    pub const fn new(red: T, green: T, blue: T) -> Self {
         Rgb {
-            red: PosNormalBoundedChannel::new(red),
-            green: PosNormalBoundedChannel::new(green),
-            blue: PosNormalBoundedChannel::new(blue),
+            red: PosNormalBoundedChannel::new_const(red),
+            green: PosNormalBoundedChannel::new_const(green),
+            blue: PosNormalBoundedChannel::new_const(blue),
         }
     }
 

--- a/src/white_point/deg_10.rs
+++ b/src/white_point/deg_10.rs
@@ -30,7 +30,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for A where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for A
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = A;
+}
 
 /// {obsolete} Direct sunlight at noon.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -56,7 +61,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for B where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for B
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = B;
+}
 /// {obsolete} Average / North sky Daylight.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct C;
@@ -81,7 +91,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for C where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for C
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = C;
+}
 /// Horizon Light. ICC profile PCS.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct D50;
@@ -106,7 +121,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D50 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D50
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D50;
+}
 /// Mid-morning / Mid-afternoon Daylight.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct D55;
@@ -131,7 +151,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D55 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D55
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D55;
+}
 /// Noon Daylight: Television, sRGB color space.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct D65;
@@ -156,7 +181,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D65 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D65
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D65;
+}
 /// North sky Daylight.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct D75;
@@ -181,7 +211,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D75 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D75
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D75;
+}
 /// Equal energy.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct E;
@@ -206,7 +241,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for E where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for E
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = E;
+}
 /// Daylight Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F1;
@@ -231,7 +271,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F1 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F1
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F1;
+}
 /// Cool White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F2;
@@ -256,7 +301,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F2 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F2
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F2;
+}
 /// White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F3;
@@ -281,7 +331,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F3 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F3
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F3;
+}
 /// Warm White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F4;
@@ -306,7 +361,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F4 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F4
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F4;
+}
 /// Daylight Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F5;
@@ -331,7 +391,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F5 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F5
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F5;
+}
 /// Lite White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F6;
@@ -356,7 +421,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F6 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F6
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F6;
+}
 /// D65 simulator, Daylight simulator.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F7;
@@ -381,7 +451,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F7 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F7
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F7;
+}
 /// D50 simulator, Sylvania F40 Design 50.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F8;
@@ -406,7 +481,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F8 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F8
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F8;
+}
 /// Cool White Deluxe Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F9;
@@ -431,7 +511,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F9 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F9
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F9;
+}
 /// Philips TL85, Ultralume 50.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F10;
@@ -456,7 +541,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F10 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F10
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F10;
+}
 /// Philips TL84, Ultralume 40.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F11;
@@ -481,7 +571,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F11 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F11
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F11;
+}
 /// Philips TL83, Ultralume 30.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
 pub struct F12;
@@ -506,4 +601,9 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F12 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F12
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F12;
+}

--- a/src/white_point/deg_2.rs
+++ b/src/white_point/deg_2.rs
@@ -30,7 +30,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for A where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for A
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = A;
+}
 
 /// {obsolete} Direct sunlight at noon.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -56,7 +61,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for B where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for B
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = B;
+}
 
 /// {obsolete} Average / North sky Daylight.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -82,7 +92,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for C where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for C
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = C;
+}
 
 /// Horizon Light. ICC profile PCS.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -108,7 +123,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D50 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D50
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D50;
+}
 
 /// Mid-morning / Mid-afternoon Daylight.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -134,7 +154,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D55 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D55
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D55;
+}
 
 /// Noon Daylight: Television, sRGB color space.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -160,7 +185,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D65 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D65
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D65;
+}
 
 /// North sky Daylight.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -186,7 +216,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for D75 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for D75
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = D75;
+}
 
 /// Equal energy.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -212,7 +247,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for E where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for E
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = E;
+}
 
 /// Daylight Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -238,7 +278,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F1 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F1
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F1;
+}
 
 /// Cool White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -264,7 +309,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F2 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F2
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F2;
+}
 
 /// White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -290,7 +340,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F3 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F3
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F3;
+}
 
 /// Warm White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -316,7 +371,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F4 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F4
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F4;
+}
 
 /// Daylight Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -342,7 +402,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F5 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F5
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F5;
+}
 
 /// Lite White Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -368,7 +433,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F6 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F6
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F6;
+}
 
 /// D65 simulator, Daylight simulator.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -394,7 +464,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F7 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F7
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F7;
+}
 
 /// D50 simulator, Sylvania F40 Design 50.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -420,7 +495,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F8 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F8
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F8;
+}
 
 /// Cool White Deluxe Fluorescent.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -446,7 +526,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F9 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F9
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F9;
+}
 
 /// Philips TL85, Ultralume 50.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -472,7 +557,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F10 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F10
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F10;
+}
 
 /// Philips TL84, Ultralume 40.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -498,7 +588,12 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F11 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F11
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F11;
+}
 
 /// Philips TL83, Ultralume 30.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Copy)]
@@ -524,4 +619,9 @@ where
         )
     }
 }
-impl<T> UnitWhitePoint<T> for F12 where T: Float + FreeChannelScalar + PosNormalChannelScalar {}
+impl<T> UnitWhitePoint<T> for F12
+where
+    T: Float + FreeChannelScalar + PosNormalChannelScalar,
+{
+    const DEFAULT: Self = F12;
+}

--- a/src/white_point/mod.rs
+++ b/src/white_point/mod.rs
@@ -27,7 +27,10 @@ pub trait WhitePoint<T>: Clone + PartialEq {
 }
 
 /// A `WhitePoint` which carries no data
-pub trait UnitWhitePoint<T>: WhitePoint<T> + Default + Copy {}
+pub trait UnitWhitePoint<T>: WhitePoint<T> + Default + Copy {
+    /// The default value for this white point (const function friendly)
+    const DEFAULT: Self;
+}
 
 impl<'a, T, U> WhitePoint<T> for &'a U
 where


### PR DESCRIPTION
This adds the `const` keyword to the `fn new(...)` declaration where possible.

This makes it possible to declare color constants:
```rust
const RED: Rgb<u8> = Rgb::new(255, 0, 0);
```